### PR TITLE
Rescored "Quadruple Break Up" from 25 to 50

### DIFF
--- a/RA Scripts/Legend of Zelda, The Phantom Hourglass.rascript
+++ b/RA Scripts/Legend of Zelda, The Phantom Hourglass.rascript
@@ -576,7 +576,7 @@ function swordStatus() => obyte(swordDataPointer() + 0x64)
 function IsUsingSword() => swordStatus() == 0x3 && swordItemAnimationId() != 0xff
 function JustUsedSword() => Delta(swordStatus()) != 0x3 && IsUsingSword()
 function ghostKey() => obit5(0x1b5542)
-achievement(title = "Quadruple Break Up [m]", points = 25,
+achievement(title = "Quadruple Break Up [m]", points = 50, id = 143361, badge = "160107",
     description = "Win at Dead Man's Volley and earn the Ghost Key using thirty-six sword swings or fewer.",
     trigger = once(IsInLocation("Cubus") && WasInLocation("GhostShip")) && never(repeated(36, JustUsedSword()))
         && never(!IsInLocation("Cubus")) && WasBitflagSetInGame(ghostKey())


### PR DESCRIPTION
With all the dropped inputs, it just ended up being too frustrating in playtesting. A score of 50 makes it more in line with the effort required to figure out a reliable strategy to earn it despite that.