### PR TITLE
[Re:coded] Fix save protection workaround

### DIFF
--- a/RA Scripts/Kingdom Hearts Recoded.rascript
+++ b/RA Scripts/Kingdom Hearts Recoded.rascript
@@ -1057,9 +1057,9 @@ function menuId() => word(0x0bea84)
 function saveLoadPtrAddr() => 0x0c5e00
 function saveLoadPtr() => tbyte(saveLoadPtrAddr())
 function loadState() => byte(saveLoadPtr() + 4)
-function LoadScreenIsTransitioningToLoadedSaveFile() => loadState() == 0x9
 function OldSaveLoadState() => byte(prior(saveLoadPtr()) + 4)
 
+// 0x9 means that it's transitioning to a loaded save file; it's what we're using to determine when a pauselock can activate.
 function IsLoadingSaveFile() => !IsPointer(saveLoadPtrAddr()) && WasPointer(saveLoadPtrAddr()) && OldSaveLoadState() == 0x9
 
 function IsOnSaveOrLoadMenu() => menuId() == 0x6

--- a/RA Scripts/Kingdom Hearts Recoded.rascript
+++ b/RA Scripts/Kingdom Hearts Recoded.rascript
@@ -219,6 +219,9 @@ rich_presence_display("Somewhere in the datascape...")
 
 function Delta(addr) => prev(addr)
 
+function IsPointer(addr) => byte(addr + 3) == 0x2
+function WasPointer(addr) => prior(byte(addr + 3)) == 0x2
+
 // Returns a new pointer address at the given half-address with a given negative offset.
 // Intended to standardize usages of negative pointer offsets, since those are not supported with the current tools.
 // ---
@@ -1051,15 +1054,20 @@ function status() => word(0x056f50)
 // 0x12 = Tutorials
 function menuId() => word(0x0bea84)
 
-function IsFileLoaded() => status() != 0x0 && status() != 0x3 && !IsOnSaveOrLoadMenu()
+function saveLoadPtrAddr() => 0x0c5e00
+function saveLoadPtr() => tbyte(saveLoadPtrAddr())
+function loadState() => byte(saveLoadPtr() + 4)
+function LoadScreenIsTransitioningToLoadedSaveFile() => loadState() == 0x9
+function OldSaveLoadState() => byte(prior(saveLoadPtr()) + 4)
 
-function IsLoadingSaveFile() => prior(titleScreenStatus()) == 0x8 && titleScreenStatus() == 0
+function IsLoadingSaveFile() => !IsPointer(saveLoadPtrAddr()) && WasPointer(saveLoadPtrAddr()) && Delta(OldSaveLoadState()) == 0x9 && OldSaveLoadState() != 0x9
 
 function IsOnSaveOrLoadMenu() => menuId() == 0x6
 
 function IsOnLoadMenu() => titleScreenStatus() == 8
 
 function IsAlwaysInGame() => unless(IsOnSaveOrLoadMenu()) && never(IsOnLoadMenu()) && never(IsOnTitleScreen())
+    && unless(!IsPointer(saveLoadPtrAddr()) && WasPointer(saveLoadPtrAddr()) && Delta(OldSaveLoadState()) == 0x9)
 
 function WasValueSet(mem, oldValue, newValue)
 {
@@ -1104,7 +1112,7 @@ function GenerateSaveProtectedAchievementFromConditions(cheevo, conditions, only
     {
         condition = conditions[i]
         
-        // This is the score when the game is loaded. If he loaded score is greater than or equal to the threshold--that is,
+        // This is the score when the game is loaded. If the loaded score is greater than or equal to the threshold--that is,
         // if the save file would satisfy enough conditions to trigger the achievement on load--this should trigger a
         // permanant pauselock to serve as save protection.
         array_push(loadedCounts, once(condition["countsWhen"] && IsLoadingSaveFile()))

--- a/RA Scripts/Kingdom Hearts Recoded.rascript
+++ b/RA Scripts/Kingdom Hearts Recoded.rascript
@@ -183,7 +183,7 @@ function BossScoreIsDisplayedAndAtLeast(threshold)
 // 5 = Title Screen almost ready
 // 6 = Title Screen ready
 // 8 = Load Menu
-function titleScreenStatus() => byte(0x19c494)
+function titleScreenStatus() => dword(0x19c494)
 
 function sessionPlayTime() => dword(0x056e9c)
 function savedPlayTime() => dword(0x198360)
@@ -1060,7 +1060,7 @@ function loadState() => byte(saveLoadPtr() + 4)
 function LoadScreenIsTransitioningToLoadedSaveFile() => loadState() == 0x9
 function OldSaveLoadState() => byte(prior(saveLoadPtr()) + 4)
 
-function IsLoadingSaveFile() => !IsPointer(saveLoadPtrAddr()) && WasPointer(saveLoadPtrAddr()) && Delta(OldSaveLoadState()) == 0x9 && OldSaveLoadState() != 0x9
+function IsLoadingSaveFile() => !IsPointer(saveLoadPtrAddr()) && WasPointer(saveLoadPtrAddr()) && OldSaveLoadState() == 0x9
 
 function IsOnSaveOrLoadMenu() => menuId() == 0x6
 


### PR DESCRIPTION
Using the save/load state pointer to determine if we're loading or saving. Appears to work for our late-game save, but one achievement triggers in the early-game save. Must investigate further.