### PR TITLE
Removed enemy count check from the "Sleeping Death" achievement

### DIFF
--- a/RA Scripts/Kingdom Hearts Birth by Sleep Final Mix.rascript
+++ b/RA Scripts/Kingdom Hearts Birth by Sleep Final Mix.rascript
@@ -1120,7 +1120,7 @@ achievement(title = "Sleeping Death [m]", points = 10, id = 187055, badge = "207
         ) && TriggerConditionsMetForCharacters({
             Terra(): FirestormLearned(),
             Aqua(): DeckCapacityIncreased()
-        }, true) && trigger_when(Delta(numberOfActiveEnemies()) >= 1 && numberOfActiveEnemies() == 0)
+        }, true)
         && IsAtLeastOnDifficulty("Proud") && level() <= 9
         && never(!IsInLocation("DwarfMirror"))
         && never(IsUsingDLink())


### PR DESCRIPTION
This would sometimes cause an issue where the achievement wouldn't trigger if, somehow, the Spirit of the Magic Mirror were diving into the ground or using one of its special duplication attacks when it was defeated. This was likely code that snuck in from the "Syncopation" achievement but was never removed.