### PR TITLE
[Chain of Memories] "Technical Tightrope" input fix

### DIFF
--- a/RA Scripts/Kingdom Hearts Chain of Memories.rascript
+++ b/RA Scripts/Kingdom Hearts Chain of Memories.rascript
@@ -2247,9 +2247,10 @@ achievement(
 
 function TotalButtonsUsed(buttonThreshold)
 {
-    return tally(buttonThreshold, [ once(aIsPressed() == 1), once(bIsPressed() == 1), once(lIsPressed() == 1), once(rIsPressed() == 1),
-        once(startIsPressed() == 1), once(selectIsPressed() == 1), once(dpadUpPressed() == 1), once(dpadDownPressed() == 1),
-        once(dpadLeftPressed() == 1), once(dpadRightPressed() == 1) ])
+    return tally(buttonThreshold, [ once(aIsPressed() == 1 && Delta(aIsPressed()) == 0), once(bIsPressed() == 1 && Delta(bIsPressed()) == 0), once(lIsPressed() == 1 && Delta(lIsPressed()) == 0),
+        once(rIsPressed() == 1 && Delta(rIsPressed()) == 0), once(startIsPressed() == 1 && Delta(startIsPressed()) == 0), once(selectIsPressed() == 1 && Delta(selectIsPressed()) == 0),
+        once(dpadUpPressed() == 1 && Delta(dpadUpPressed()) == 0), once(dpadDownPressed() == 1 && Delta(dpadDownPressed()) == 0), once(dpadLeftPressed() == 1 && Delta(dpadLeftPressed()) == 0),
+        once(dpadRightPressed() == 1 && Delta(dpadRightPressed()) == 0) ])
 }
 
 buttonLimit = 4


### PR DESCRIPTION
Fixed an issue with "Technical Tightrope" where inputs being held down (such as Start, which skips cutscenes) prior to the battle starting would count as inputs against the player.