### PR TITLE
[Re:coded] Fixed a false trigger issue with "Smooth Operator"

### DIFF
--- a/RA Scripts/Kingdom Hearts Recoded.rascript
+++ b/RA Scripts/Kingdom Hearts Recoded.rascript
@@ -1872,8 +1872,9 @@ function HPCheatIsBeingUsed()
 
 function dodgeRollActive() => bit0(0x1986f0)
 achievement(title = "Smooth Operator", description = "Defeat the Darkside without the Dodge Roll ability equipped (Critical Mode, Level 2 or below, no HP Cheat).",
-    points = 5,
-    trigger = IsAtLeastOnDifficulty("Critical") && dodgeRollActive() == 0 && JustDefeatedEnemy("Darkside") && Level() <= 2 && never(HPCheatIsBeingUsed())
+    points = 5, id = 153005, badge = "171730",
+    trigger = IsAtLeastOnDifficulty("Critical") && dodgeRollActive() == 0 && trigger_when(JustDefeatedEnemy("Darkside")) && Level() <= 2 && never(HPCheatIsBeingUsed())
+        && IsInLocation("DestinyStorm")
 )
 
 achievement(title = "I Am the New God", description = "Earn a Star rank against the Darkside (Proud Mode or higher, Level 5 or below, no HP Cheat).",


### PR DESCRIPTION
The achievement could incorrectly trigger during the tutorial while opening the save menu due to flickering memory if the player was (1) <= Level 2, (2) Critical Mode was enabled, and (3) if Dodge Roll was disabled.