### PR TITLE
[Chain of Memories] "Come Forth, Blue-Eyes White Dragon!" Mushu fix

### DIFF
--- a/RA Scripts/Kingdom Hearts Chain of Memories.rascript
+++ b/RA Scripts/Kingdom Hearts Chain of Memories.rascript
@@ -2002,7 +2002,7 @@ achievement(
 )
 
 function marluxiaIIEncounterId() => 0x9c
-function PlayerIsUsingSummon() => Delta(soraBattleState()) == 0x12 || Delta(soraBattleState()) >= 0x17 && Delta(soraBattleState()) <= 0x1b
+function PlayerIsUsingSummon() => prior(soraBattleState()) == 0x12 || prior(soraBattleState()) >= 0x17 && prior(soraBattleState()) <= 0x1b
 
 // Appears to affect which summon is used during Marluxia II (16-bit)
 //


### PR DESCRIPTION
Fixed, or at least worked around, an issue where if the player defeated Marluxia with Mushu, the achievement wouldn't trigger. My notes from the ticket in question:

*So, weirdly enough, this issue appeared to be happening because for at least Mushu (perhaps this also applies to all the non-transformation summons), the state that determines what summon is being used is immediately set to some different state when Marluxia is defeated--something initial testing didn't catch. This makes Delta flags useless here, as the state is set before the battle pointer is nullified, so it would never detect if the battle ended while the summon (or at least Mushu) is active. Replacing them with Prior flags appears to fix the issue. The problem, however, is that I'm wary of using Prior flags out of principle, as it's possible that this may lead to achievements being vulnerable to triggering at the wrong time. I didn't encounter any of these issues while testing the fix, but if it does happen in the future, I'll have to revisit the solution. For now, though, the issue has been fixed.*