### PR TITLE
Leaderboards and trigger update

### DIFF
--- a/RA Scripts/Croc Legend of the Gobbos.rascript
+++ b/RA Scripts/Croc Legend of the Gobbos.rascript
@@ -111,53 +111,55 @@ function IsLevelWithIdComplete(levelId) => IsInLevelWithId(levelId) && IsLevelCo
 
 function LevelHasLoadedAndIdHasNotChanged() => once(IsLevelLoading()) && never(Delta(selectedLevel()) != selectedLevel())
 
-function IsLevelCheckpointValid(levelId) => IsInLevelWithId(levelId) && once(IsLevelLoading())
+function LevelCheckpointWasReached(levelId) => once(IsLevelLoading() && IsInLevelWithId(levelId))
+
+function LevelCheckpointIsValid(levelId) => LevelCheckpointWasReached(levelId) && never(!IsInLevelWithId(levelId))
 
 levelCodesToLevelInfo = {
-    "1-1": { "id": 0x0, "name": "And So the Adventure Begins", "timeLimit": 39, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
-    "1-2": { "id": 0x1, "name": "Underground Overground", "timeLimit": 41, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
-    "1-3": { "id": 0x2, "name": "Shoutin' Lava Lava Lava", "timeLimit": 48, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
+    "1-1": { "id": 0x0, "name": "And So the Adventure Begins", "timeLimit": 39, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7642 },
+    "1-2": { "id": 0x1, "name": "Underground Overground", "timeLimit": 41, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7643 },
+    "1-3": { "id": 0x2, "name": "Shoutin' Lava Lava Lava", "timeLimit": 48, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7644 },
     "1-B1": { "id": 0x3, "name": "Lair of the Feeble", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1 },
-    "1-S1": { "id": 0x4, "name": "The Curvy Caverns", "timeLimit": 84, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1 },
-    "1-4": { "id": 0x5, "name": "The Tumbling Dantini", "timeLimit": 52, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
-    "1-5": { "id": 0x6, "name": "Cave Fear", "timeLimit": 45, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
-    "1-6": { "id": 0x7, "name": "Darkness Descends", "timeLimit": 66, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1 },
+    "1-S1": { "id": 0x4, "name": "The Curvy Caverns", "timeLimit": 84, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1, "lbId": 7650 },
+    "1-4": { "id": 0x5, "name": "The Tumbling Dantini", "timeLimit": 52, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7651 },
+    "1-5": { "id": 0x6, "name": "Cave Fear", "timeLimit": 45, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7652 },
+    "1-6": { "id": 0x7, "name": "Darkness Descends", "timeLimit": 66, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 1, "lbId": 7653 },
     "1-B2": { "id": 0x8, "name": "Fight Night with Flibby", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1 },
-    "1-S2": { "id": 0x9, "name": "The Twisty Tunnels", "timeLimit": 65, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1 },
-    "2-1": { "id": 0xa, "name": "The Ice of Life", "timeLimit": 66, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
-    "2-2": { "id": 0xb, "name": "Be Wheely Careful", "timeLimit": 83, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
-    "2-3": { "id": 0xc, "name": "Riot Brrrrr", "timeLimit": 92, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
+    "1-S2": { "id": 0x9, "name": "The Twisty Tunnels", "timeLimit": 65, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 1, "lbId": 7654 },
+    "2-1": { "id": 0xa, "name": "The Ice of Life", "timeLimit": 66, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7661 },
+    "2-2": { "id": 0xb, "name": "Be Wheely Careful", "timeLimit": 83, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7662 },
+    "2-3": { "id": 0xc, "name": "Riot Brrrrr", "timeLimit": 92, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7663 },
     "2-B1": { "id": 0xd, "name": "Chumly’s Snow Den", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2 },
-    "2-S1": { "id": 0xe, "name": "Clouds of Ice", "timeLimit": 83, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2 },
-    "2-4": { "id": 0xf, "name": "I Snow Him So Well", "timeLimit": 122, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
-    "2-5": { "id": 0x10, "name": "Say No Snow", "timeLimit": 104, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
-    "2-6": { "id": 0x11, "name": "License to Chill", "timeLimit": 82, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2 },
+    "2-S1": { "id": 0xe, "name": "Clouds of Ice", "timeLimit": 83, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2, "lbId": 7664 },
+    "2-4": { "id": 0xf, "name": "I Snow Him So Well", "timeLimit": 122, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7665 },
+    "2-5": { "id": 0x10, "name": "Say No Snow", "timeLimit": 104, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7666 },
+    "2-6": { "id": 0x11, "name": "License to Chill", "timeLimit": 82, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 2, "lbId": 7667 },
     "2-B2": { "id": 0x12, "name": "Demon Itsy’s Ice Palace", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2 },
-    "2-S2": { "id": 0x13, "name": "Ice Bridge to Eternity", "timeLimit": 91, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2 },
-    "3-1": { "id": 0x14, "name": "Lights, Camel, Action!", "timeLimit": 74, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3 },
-    "3-2": { "id": 0x15, "name": "Mud Pit Mania", "timeLimit": 108, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3 },
-    "3-3": { "id": 0x16, "name": "Goin' Underground", "timeLimit": 142, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3 },
+    "2-S2": { "id": 0x13, "name": "Ice Bridge to Eternity", "timeLimit": 91, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 2, "lbId": 7668 },
+    "3-1": { "id": 0x14, "name": "Lights, Camel, Action!", "timeLimit": 74, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3, "lbId": 7669 },
+    "3-2": { "id": 0x15, "name": "Mud Pit Mania", "timeLimit": 108, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3, "lbId": 7670 },
+    "3-3": { "id": 0x16, "name": "Goin' Underground", "timeLimit": 142, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 3, "lbId": 7671 },
     "3-B1": { "id": 0x17, "name": "The Deadly Tank of Neptuna", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 3 },
-    "3-S1": { "id": 0x18, "name": "Arabian Heights", "timeLimit": 123, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 3 },
-    "3-4": { "id": 0x19, "name": "Sand and Freedom", "timeLimit": 203, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3 },
-    "3-5": { "id": 0x1a, "name": "Leap of Faith", "timeLimit": 199, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3 },
-    "3-6": { "id": 0x1b, "name": "Life's a Beach", "timeLimit": 133, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3 },
+    "3-S1": { "id": 0x18, "name": "Arabian Heights", "timeLimit": 123, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 3, "lbId": 7673 },
+    "3-4": { "id": 0x19, "name": "Sand and Freedom", "timeLimit": 203, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3, "lbId": 7674 },
+    "3-5": { "id": 0x1a, "name": "Leap of Faith", "timeLimit": 199, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3, "lbId": 7675 },
+    "3-6": { "id": 0x1b, "name": "Life's a Beach", "timeLimit": 133, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 3, "lbId": 7676 },
     "3-B2": { "id": 0x1c, "name": "Cactus Jack’s Ranch", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 3 },
-    "3-S2": { "id": 0x1d, "name": "Defeato Burrito", "timeLimit": 116, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 3 },
-    "4-1": { "id": 0x1e, "name": "The Tower of Power", "timeLimit": 200, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 4 },
-    "4-2": { "id": 0x1f, "name": "Hassle in the Castle", "timeLimit": 153, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4 },
-    "4-3": { "id": 0x20, "name": "Dungeon of Defright", "timeLimit": 89, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4 },
+    "3-S2": { "id": 0x1d, "name": "Defeato Burrito", "timeLimit": 116, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 3, "lbId": 7679 },
+    "4-1": { "id": 0x1e, "name": "The Tower of Power", "timeLimit": 200, "hasGobbos": 1, "difficultyBonus": 1, "worldId": 4, "lbId": 7680 },
+    "4-2": { "id": 0x1f, "name": "Hassle in the Castle", "timeLimit": 153, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4, "lbId": 7681 },
+    "4-3": { "id": 0x20, "name": "Dungeon of Defright", "timeLimit": 89, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4, "lbId": 7682 },
     "4-B1": { "id": 0x21, "name": "Fosley’s Freaky Donut", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4 },
-    "4-S1": { "id": 0x22, "name": "Smash and See", "timeLimit": 175, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4 },
-    "4-4": { "id": 0x23, "name": "Ballistic Meg's Fairway", "timeLimit": 178, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4 },
-    "4-5": { "id": 0x24, "name": "Swipe Swiftly's Wicked Ride", "timeLimit": 180, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4 },
-    "4-6": { "id": 0x25, "name": "Panic at Platform Pete's Lair", "timeLimit": 214, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4 },
+    "4-S1": { "id": 0x22, "name": "Smash and See", "timeLimit": 175, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4, "lbId": 7693 },
+    "4-4": { "id": 0x23, "name": "Ballistic Meg's Fairway", "timeLimit": 178, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4, "lbId": 7694 },
+    "4-5": { "id": 0x24, "name": "Swipe Swiftly's Wicked Ride", "timeLimit": 180, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4, "lbId": 7695 },
+    "4-6": { "id": 0x25, "name": "Panic at Platform Pete's Lair", "timeLimit": 214, "hasGobbos": 1, "difficultyBonus": 0, "worldId": 4, "lbId": 7696 },
     "4-B2": { "id": 0x26, "name": "Baron Dante’s Funky Inferno", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4 },
-    "4-S2": { "id": 0x27, "name": "Jailhouse Croc", "timeLimit": 98, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4 },
-    "5-1": { "id": 0x28, "name": "And So the Adventure Returns", "timeLimit": 118, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 5 },
-    "5-2": { "id": 0x29, "name": "Diet Brrrrr", "timeLimit": 126, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 5 },
-    "5-3": { "id": 0x2a, "name": "Trial on the Nile", "timeLimit": 163, "hasGobbos": 0, "difficultyBonus": 2, "worldId": 5 },
-    "5-4": { "id": 0x2b, "name": "Crox Interactive", "timeLimit": 119, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 5 },
+    "4-S2": { "id": 0x27, "name": "Jailhouse Croc", "timeLimit": 98, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 4, "lbId": 7697 },
+    "5-1": { "id": 0x28, "name": "And So the Adventure Returns", "timeLimit": 118, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 5, "lbId": 7698 },
+    "5-2": { "id": 0x29, "name": "Diet Brrrrr", "timeLimit": 126, "hasGobbos": 0, "difficultyBonus": 1, "worldId": 5, "lbId": 7699 },
+    "5-3": { "id": 0x2a, "name": "Trial on the Nile", "timeLimit": 163, "hasGobbos": 0, "difficultyBonus": 2, "worldId": 5, "lbId": 7700 },
+    "5-4": { "id": 0x2b, "name": "Crox Interactive", "timeLimit": 119, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 5, "lbId": 7701 },
     "5-B": { "id": 0x2c, "name": "Secret Sentinel", "timeLimit": 0, "hasGobbos": 0, "difficultyBonus": 0, "worldId": 5 },
 }
 
@@ -238,27 +240,26 @@ for levelCode in levelCodesToLevelInfo
     difficultyBonus = levelCodesToLevelInfo[levelCode]["difficultyBonus"]
     isLevelComplete = IsLevelWithIdComplete(levelId)
     frameLimit = SecondsToFrames(timeLimit)
+    frameIncrementedInGame = frameIncremented() && !IsPaused()
     
     // Only compile the achievements and leaderboards if there is an actual time limit greater than zero.
     if (timeLimit > 0)
     {
         achievement(title = "Speed Demon! (" + levelCode + ")",
             description = "Complete \"" + levelName + "\" within " + SecondsToFormat(timeLimit) + ".",
-            points = GetScore(timeLimit, difficultyBonus), trigger =
-                isLevelComplete && IsLevelCheckpointValid(levelId) && never(selectedLevel() != levelId) // Core
-                && (
-                always_false() // Alt 1
-    
-                || never(repeated(frameLimit, frameIncremented())) // Alt 2
-                    && never(!IsInLevel()) && unless(IsPaused())
-            ))
+            points = GetScore(timeLimit, difficultyBonus),
+            trigger = LevelCheckpointIsValid(levelId)
+                && trigger_when(isLevelComplete)
+                && never(LevelCheckpointWasReached(levelId) && repeated(frameLimit, frameIncrementedInGame))
+        )
         
         leaderboard(title = "Time Trial: " + levelCode + " - " + levelCodesToLevelInfo[levelCode]["name"],
             description = "Ring the gong in the fastest time you can!",
-            start = IsLevelCheckpointValid(levelId) && IsInLevel() && never(selectedLevel() != Delta(selectedLevel())),
-            cancel = !IsInLevel(),
-            submit = isLevelComplete && IsLevelCheckpointValid(levelId),
-            value = measured(frameIncremented()),
+            start = LevelCheckpointWasReached(levelId) && never(!IsInLevel()),
+            cancel = !IsInLevel() || selectedLevel() != levelId,
+            submit = isLevelComplete && LevelCheckpointWasReached(levelId),
+            value = measured(frameIncrementedInGame),
+            id = levelCodesToLevelInfo[levelCode]["lbId"],
             format = "FRAMES")
     }
 }
@@ -424,20 +425,20 @@ for levelCode in levelsWithJigsawPiecesToIndex
 
     achievement(title = "Puzzler (" + levelCode + ")", description = "Collect the Jigsaw Piece hidden in Level " + levelCode + ".",
         points = 5, trigger =
-            DidCollectJigsawPieceInCurrentLevel() &&
-            once(IsLevelCheckpointValid(levelId) && PuzzlePieceStatusInLevel(levelCode) == 0) &&
-            PuzzlePieceStatusInLevel(levelCode) > 0 && never(!IsInLevel())
+            DidCollectJigsawPieceInCurrentLevel()
+            && LevelCheckpointIsValid(levelId)
+            && never(!IsInLevel())
     )
     
     masterPuzzlerAlt = masterPuzzlerAlt ||
         once(Delta(PuzzlePieceStatusInLevel(levelCode)) != PuzzlePieceStatusInLevel(levelCode))
-        && once(IsLevelCheckpointValid(levelId) && PuzzlePieceStatusInLevel(levelCode) == 0)
+        && once(LevelCheckpointIsValid(levelId) && PuzzlePieceStatusInLevel(levelCode) == 0)
     
     masterPuzzlerCore = masterPuzzlerCore && PuzzlePieceStatusInLevel(levelCode) > 0 && never(!IsInLevel())
 }
 
-achievement(title = "Master Puzzler", description = "Collect all eight Jigsaw Pieces.", points = 10, trigger =
-    masterPuzzlerCore && masterPuzzlerAlt
+achievement(title = "Master Puzzler", description = "Collect all eight Jigsaw Pieces.", points = 10, id = 103663, badge = "113354",
+    trigger = masterPuzzlerCore && masterPuzzlerAlt
 )
 
 
@@ -479,15 +480,14 @@ achievementInfo = {
 function IsLevelCompleteWithoutTakingDamageOrLosingALife(levelId)
 {
     return never(Delta(currentLevelCrystals()) > currentLevelCrystals()) && never(Delta(currentLives()) > currentLives())
-        && IsLevelComplete() && never(!IsInLevel()) && once(IsLevelCheckpointValid(levelId))
+        && trigger_when(IsLevelComplete()) && never(!IsInLevel()) && once(LevelCheckpointWasReached(levelId))
 }
 
 for levelCode in achievementInfo
 {
     info = achievementInfo[levelCode]
     achievement(title = info["title"], description = info["description"], points = info["points"],
-        trigger =
-            IsLevelCompleteWithoutTakingDamageOrLosingALife(levelCodesToLevelInfo[levelCode]["id"]) 
+        trigger = IsLevelCompleteWithoutTakingDamageOrLosingALife(levelCodesToLevelInfo[levelCode]["id"])
     )
 }
 
@@ -575,4 +575,3 @@ rich_presence_conditional_display(IsLevelComplete(), "Viewing level results...")
 rich_presence_conditional_display(gameState() == 4, "Running through Level {0}",
     rich_presence_lookup("Level", selectedLevel(), levelIdsToNames)
 )
-


### PR DESCRIPTION
Fixed an issue where leaderboards and their corresponding achievements would not keep time precisely the same way. Leaderboards are now considered a source of truth in regards to achievement times.

Also added Trigger flags to the speedrunning achievements to make more obvious in the future if there are more time discrepancies.