### PR TITLE
"Give Me Strength" fix

### DIFF
--- a/RA Scripts/Kingdom Hearts Birth by Sleep Final Mix.rascript
+++ b/RA Scripts/Kingdom Hearts Birth by Sleep Final Mix.rascript
@@ -731,7 +731,7 @@ function IsPerformingASituationalCommand() => characterState() == 0x1d
 function dLinkPointer() => tbyte(0xb59ce8)
 function dLinkCharge() => dword(dLinkPointer() + 0x1000000 + 0x3c) // todo: actually a float; change when supported
 function commandGaugeCharge() => dword(dLinkPointer() + 0x1000000 + 0x1d30) // todo: also a float
-function IsUsingDLink() => Delta(dLinkCharge()) > dLinkCharge() && dLinkPointer() != 0
+function IsUsingDLink() => word(characterFieldPointer() + 0x1000000 + 0x102c) > 0 && characterFieldPointer() != 0
 function CommandGaugeEmptied() => Delta(commandGaugeCharge()) != commandGaugeCharge() && commandGaugeCharge() == 0
 
 function IsUsingAnyGivenCommand(haystack)


### PR DESCRIPTION
Fixed an issue where "Give Me Strength" would sometimes fail if a player inputted a battle command while a D-Link was active.