### PR TITLE
"Siblings' Last Quarrel" fix

### DIFF
--- a/RA Scripts/Fire Emblem Genealogy of the Holy War.rascript
+++ b/RA Scripts/Fire Emblem Genealogy of the Holy War.rascript
@@ -1251,9 +1251,10 @@ achievement(title = "Consolation Loot [m]", points = 10, id = 130718, badge = "1
 
 earthSwordId = 0x22
 function raquesisRetrievedEarthSword() => bit7(0x0052c4)
+function eldiganWasKilled() => bit2(0x0052c6)
 achievement(title = "Siblings' Last Quarrel [m]", points = 10, id = 130715, badge = "143912",
     description = "Receive the Earth Sword from Eldigan in Chapter 3.",
-    trigger = chapter() == 3 && WasBitflagSetInGame(raquesisRetrievedEarthSword())
+    trigger = chapter() == 3 && WasBitflagSetInGame(raquesisRetrievedEarthSword()) && eldiganWasKilled() == 0
 )
 
 achievement(title = "Arden's Resolve [m]", points = 3, id = 130730, badge = "143927",


### PR DESCRIPTION
Fixed an issue where getting the Silver Sword at the end of the chapter would trigger the achievement if Eldigan was killed earlier in the chapter.