### PR TITLE
Clarified "At Arm's Length"'s description

### DIFF
--- a/RA Scripts/World Ends with You, The.rascript
+++ b/RA Scripts/World Ends with You, The.rascript
@@ -2549,8 +2549,8 @@ achievement(title = "Looks Like We Don't Have a Choice!", points = 10,
 )
 
 positivePins = GetPinsByTrait("Element", "Pos")
-achievement(title = "At Arm's Length", points = 10,
-    description = "Defeat Reaper Beat without any Positive-type pins equipped (Normal or higher, Level 35 or below).",
+achievement(title = "At Arm's Length", points = 10, id = 120647, badge = "131640",
+    description = "Defeat the Reaper Beat boss Noise without any Positive-type pins equipped (Normal or higher, Level 35 or below).",
     trigger = enemyId() == GetEnemyIdByName("Reaper Beat") && EnterBattleCheckpointValid()
         && IsAtLeastOnDifficulty("Normal") && currentLevel() <= 35 && IsRankingRevealed()
         && never(AnyOfTheGivenPinsAreEquipped(positivePins))


### PR DESCRIPTION
The achievement description used to be the following:

"Defeat Reaper Beat without any Positive-type pins equipped (Normal or higher, Level 35 or below)."

It has been updated to state that the actual fight in question is the optional boss Noise version the player can encounter during the postgame, as opposed to the story fight during Week 2.